### PR TITLE
Fixed base path routing issue

### DIFF
--- a/deploy/k8s/api/base/deployment.yaml
+++ b/deploy/k8s/api/base/deployment.yaml
@@ -36,6 +36,8 @@ spec:
 ##             www-data -> 33
 ##            runAsUser: 33
           env:
+            - name: API_BASEPATH
+              value: /api/menu
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/src/services/api/xxAMIDOxx.xxSTACKSxx.API/Controllers/DefaultController.cs
+++ b/src/services/api/xxAMIDOxx.xxSTACKSxx.API/Controllers/DefaultController.cs
@@ -6,6 +6,9 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace xxAMIDOxx.xxSTACKSxx.API.Controllers
 {
+    /// <summary>
+    /// Endpoint to ensure we forward root requests to swagger
+    /// </summary>
     [Route("/")]
     [ApiController]
     [ApiExplorerSettings(IgnoreApi = true)]
@@ -13,7 +16,7 @@ namespace xxAMIDOxx.xxSTACKSxx.API.Controllers
     {
         public IActionResult Index()
         {
-            return Redirect("swagger");
+            return Redirect((Environment.GetEnvironmentVariable("API_BASEPATH") ?? String.Empty) + "/swagger");
         }
     }
 }

--- a/src/services/api/xxAMIDOxx.xxSTACKSxx.API/Filters/BasePathFilter.cs
+++ b/src/services/api/xxAMIDOxx.xxSTACKSxx.API/Filters/BasePathFilter.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using Swashbuckle.AspNetCore.Swagger;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace xxAMIDOxx.xxSTACKSxx.API.Filters
+{
+    /// <summary>
+    /// Adds a base path to the spec 
+    /// Required when app running behind a proxy\gateway
+    /// i.e: domain.com/api/menu/v1/health -> domain.com/v1/health 
+    /// The gateway addzremove the "/api/menu" so the BasePath should be "/api/menu"
+    /// </summary>
+    public class BasePathFilter : IDocumentFilter
+    {
+        public BasePathFilter(string basePath)
+        {
+            BasePath = basePath;
+        }
+
+        public string BasePath { get; }
+
+        public void Apply(SwaggerDocument swaggerDoc, DocumentFilterContext context)
+        {
+            if (string.IsNullOrWhiteSpace(BasePath))
+                return;
+
+            swaggerDoc.BasePath = BasePath;
+        }
+    }
+}

--- a/src/services/api/xxAMIDOxx.xxSTACKSxx.API/Startup.cs
+++ b/src/services/api/xxAMIDOxx.xxSTACKSxx.API/Startup.cs
@@ -24,11 +24,13 @@ namespace xxAMIDOxx.xxSTACKSxx.API
     {
         public IConfiguration Configuration { get; }
         private readonly IHostingEnvironment _hostingEnv;
+        private string pathBase = String.Empty;
 
         public Startup(IHostingEnvironment env, IConfiguration configuration)
         {
             _hostingEnv = env;
             Configuration = configuration;
+            pathBase = Environment.GetEnvironmentVariable("API_BASEPATH") ?? String.Empty;
         }
 
         // This method gets called by the runtime. Use this method to add services to the container.
@@ -67,13 +69,15 @@ namespace xxAMIDOxx.xxSTACKSxx.API
                         },
                         TermsOfService = "http://www.amido.com/"
                     });
-
+                    
                     c.CustomSchemaIds(type => type.FriendlyId(false));
                     c.DescribeAllEnumsAsStrings();
                     c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{_hostingEnv.ApplicationName}.xml");
 
                     // Show only operations where route starts with
                     //c.DocumentFilter<BasePathFilter>("/v1");
+                    // Sets the basePath property in the Swagger document generated
+                    c.DocumentFilter<BasePathFilter>(pathBase);
 
                     //Set default tags, shows on top, non defined tags appears at bottom
                     c.DocumentFilter<SwaggerDocumentTagger>(new Tag[] {
@@ -114,6 +118,8 @@ namespace xxAMIDOxx.xxSTACKSxx.API
 
                     // Show only operations where route starts with
                     c.DocumentFilter<VersionPathFilter>("/v1");
+                    // Sets the basePath property in the Swagger document generated
+                    c.DocumentFilter<BasePathFilter>(pathBase);
 
                     // Include DataAnnotation attributes on Controller Action parameters as Swagger validation rules (e.g required, pattern, ..)
                     // Use [ValidateModelState] on Actions to actually validate it in C# as well!
@@ -139,8 +145,10 @@ namespace xxAMIDOxx.xxSTACKSxx.API
                     c.DescribeAllEnumsAsStrings();
                     c.IncludeXmlComments($"{AppContext.BaseDirectory}{Path.DirectorySeparatorChar}{_hostingEnv.ApplicationName}.xml");
 
-                    // Sets the basePath property in the Swagger document generated
+                    // Show only operations where route starts with
                     c.DocumentFilter<VersionPathFilter>("/v2");
+                    // Sets the basePath property in the Swagger document generated
+                    c.DocumentFilter<BasePathFilter>(pathBase);
 
                     // Include DataAnnotation attributes on Controller Action parameters as Swagger validation rules (e.g required, pattern, ..)
                     // Use [ValidateModelState] on Actions to actually validate it in C# as well!
@@ -164,12 +172,13 @@ namespace xxAMIDOxx.xxSTACKSxx.API
             app.UseHttpsRedirection();
 
             app
+                .UsePathBase(pathBase)
                 .UseMvc()
                 .UseSwagger()
                 .UseSwaggerUI(c =>
                 {
                     c.DisplayOperationId();
-
+                    
                     c.SwaggerEndpoint("all/swagger.json", "Menu (all)");
                     c.SwaggerEndpoint("v1/swagger.json", "Menu (version 1)");
                     c.SwaggerEndpoint("v2/swagger.json", "Menu (version 2)");


### PR DESCRIPTION
#### 📲 What

Added base path configuration to the api and swagger to enable routing behind a proxy (ingress)

#### 🤔 Why
		
The Swagger does does not make the requests to the right endpoint when behind a proxy. The requests assume the root path and skip the base path needed by the Ingress.
		
#### 🛠 How
		
An environment variable called `API_BASEPATH` has been added to configure the application when behind a proxy.
The route should match the same routing rule defined in the Ingress configuration.

i.e:
`domain.com/api/menu/v1/menu` is routed to the api as `domain.com/v1/menu` the api does redirects based on configured base path, in this case the base path `/` but should be `/api/menu`

#### 👀 Evidence
		
When configured:
- The root of the API should redirect to the Swagger page
- The swagger ui should show `Base URL: /api/menu` according to the base set in environment variable
- Requests made using swagger or direct from browser should woth the same way.
		 
Example swagger:
![image](https://user-images.githubusercontent.com/943026/60437998-7c8f9700-9c07-11e9-9730-f01ad2acae0c.png)

#### 🕵️ How to test

Navigate to root path of api. i.e: `dev.amidostacks.com/api/menu`
The browser should be redirected to the swagger ui
The Swagger ui should show the **Base Url** in the heading(as shown image above)

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
