### PR TITLE
Bug: Added lock for concurrent calls

### DIFF
--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/MenuRepository.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/MenuRepository.cs
@@ -9,6 +9,7 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.Repositories
     {
         static System.Collections.Generic.Dictionary<Guid, Menu> storage = new System.Collections.Generic.Dictionary<Guid, Menu>();
 
+        private Object _lock = new Object();
         public async Task<Menu> GetByIdAsync(Guid id)
         {
             if (storage.ContainsKey(id))
@@ -22,20 +23,29 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.Repositories
             if (entity == null)
                 return await Task.FromResult(false);
 
-            if (storage.ContainsKey(entity.Id))
-                storage[entity.Id] = entity;
-            else
-                storage.Add(entity.Id, entity);
+            lock (_lock)
+            {
+                if (storage.ContainsKey(entity.Id))
+                    storage[entity.Id] = entity;
+                else
+                    storage.Add(entity.Id, entity);
+            }
 
             return await Task.FromResult(true);
         }
 
         public async Task<bool> DeleteAsync(Guid id)
         {
-            if (!storage.ContainsKey(id))
-                return false;
+            bool result;
+            lock (_lock)
+            {
+                if (!storage.ContainsKey(id))
+                    return false;
 
-            return await Task.FromResult(storage.Remove(id));
+                result = storage.Remove(id);
+            }
+
+            return await Task.FromResult(result);
         }
 
     }


### PR DESCRIPTION
#### 📲 What

Added lock to avoid multiple calls changing the memory storage concurrently

#### 🤔 Why
		
Concurrent calls were failing due to concurrent calls trying to save and remove data from the inMemory storage.
		
#### 🛠 How
		
Lock in the repository logic to save/delete items.

#### 👀 Evidence
		
Not needed
		 
#### 🕵️ How to test

Run the tests in parallel and see if fails

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
