### PR TITLE
Feature/449 vulnscanning

### DIFF
--- a/build/azDevOps/azure/menu-api-v2.yml
+++ b/build/azDevOps/azure/menu-api-v2.yml
@@ -131,9 +131,9 @@ variables:
 
 # Package Info
 - name: Package.File
-  value: scripts-0.0.37-master.tar.gz
+  value: scripts-0.0.36-master.tar.gz
 - name: Package.SAS
-  value: 'se=2019-09-14T14%3A32Z&sp=rl&sv=2018-03-28&ss=b&srt=sco&sig=hf5spB8zpC5IZY6h42TYrKEh18BZC/RimU2%2BKiDI3Bs%3D'
+  value: 'se=2019-09-14T13%3A36Z&sp=rl&sv=2018-03-28&ss=b&srt=sco&sig=D2UgzGvGQyITBACrB7LEmsawvo/CKITwoVXcTc4sEDU%3D'
 - name: 'Package.URI'
   value: https://amidostackspkgukstmp.blob.core.windows.net/packages/$(Package.File)?$(Package.SAS)
 
@@ -228,12 +228,8 @@ stages:
       inputs:
         targetType: 'filePath'
         filePath: $(Build.BinariesDirectory)/DevOps/Docker/new-image-scan.sh
-        arguments: $(Docker.ImageName) $(Docker.ImageTag) $(Build.ArtifactStagingDirectory)/results.json
-      continueOnError: true
-
-    - publish: $(Build.ArtifactStagingDirectory)/results.json
-      artifact: scanresults
-      displayName: 'Publish: Vulnerability Scan Result Artefact'
+        arguments: $(Docker.ImageName) $(Docker.ImageTag)
+        workingDirectory: $(Build.ArtifactStagingDirectory)
       continueOnError: true
 
 #### Vulnerability Scanning


### PR DESCRIPTION
[449-Vulnerability Scanning]

#### 📲 What

Addition of step to scan for container vulnerabilities.

#### 🤔 Why
		
To ensure container vulnerabilities are investigated and documented, potentially causing the CI process to abort when found.
		
#### 🛠 How
		
Addition of step referencing `stacks-packages` script `new-image-scan.sh`

#### 👀 Evidence
		
https://amidodevelopment.atlassian.net/wiki/spaces/TEC/pages/1199767600/ADR+31+Container+Vulnerability+Scanning+Proposed
		 
#### 🕵️ How to test

Review output of `Perform Vulnerability Scan` step in `Build > Build` stage and job.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
