### PR TITLE
fix: migrate nuget publish from amido to ensono

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,9 @@ jobs:
           TF_VAR_name_company: ${{ env.COMPANY }}
           TF_VAR_name_project: ${{ env.PROJECT }}
           TF_VAR_name_domain: "{{ env.DOMAIN }}"
+          # Helm Chart Configuration
+          HELM_CHART_FILE: "deploy/helm/stacks-dotnet"
+          HELM_VALUE_FILE: "deploy/helm/stacks-dotnet/values.yaml"
           # K8S Target Configuration
           K8S_CLUSTER_TARGET: "ensono-stacks-nonprod-ew2-eks"  # TODO: To be read from core state
           K8S_CLUSTER_IDENTIFIER: "${{ env.REGION }}" # TODO: To be read from core state

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ env:
   ROLE: "backend"
   APP_NAME: "yumido-netcore-api"
   DOMAIN: "dev-netcore-api"
-  COMPANY: "amido"
+  COMPANY: "ensono"
   PROJECT: "stacks"
   FUNCTIONAL_TESTS_SRC_DIR: src/tests/Functional
   FUNCTIONAL_TESTS_RUN_DIR: ${{ github.workspace }}/tests
@@ -169,17 +169,17 @@ jobs:
           TF_VAR_name_project: ${{ env.PROJECT }}
           TF_VAR_name_domain: "{{ env.DOMAIN }}"
           # K8S Target Configuration
-          K8S_CLUSTER_TARGET: "amido-stacks-dev-h0ax6owA"  # TODO: To be read from core state
+          K8S_CLUSTER_TARGET: "ensono-stacks-nonprod-ew2-eks"  # TODO: To be read from core state
           K8S_CLUSTER_IDENTIFIER: "${{ env.REGION }}" # TODO: To be read from core state
           K8S_INGRESS_CERT_ARN: "arn:aws:acm:eu-west-2:316154162729:certificate/17e50dfb-9fdc-4dce-92c1-8351a3961279"
           NAMESPACE: "nonprod-${{ env.DOMAIN }}"
           # K8S Additional Deploy-Templater temporary var substitutions (should be from TF outputs and per env)
-          CLOUDWATCH_LOG_GROUP: “amido-stacks-dev-h0ax6owA-logs” # TODO: To be read from core state
+          CLOUDWATCH_LOG_GROUP: “ensono-stacks-nonprod-ew2-eks # TODO: To be read from core state
           CLOUDWATCH_STREAM_PREFIX: "nonprod-${{ env.DOMAIN }}"
-          DNS_BASE_DOMAIN: "nonprodaws.amidostacks.com" # TODO: To be read from core state
+          DNS_BASE_DOMAIN: "nonprod.aws.stacks.ensono.com" # TODO: To be read from core state
           # Functional Test Configuration
           FUNCTIONAL_TESTS_RUN_DIR: /app/tests # Must match RELATIVE path from repo root that artefact is downloaded to.
-          BaseUrl: "https://nonprod-dev-netcore-api.nonprodaws.amidostacks.com/api/menu/"  # TODO: To be read from core state
+          BaseUrl: "https://nonprod-dev-netcore-api.nonprod.aws.stacks.ensono.com/api/menu/"  # TODO: To be read from core state
 
       - name: Publish Manifest File
         uses: actions/upload-artifact@v3

--- a/build/azDevOps/azure/nuget-packages-api-vars.yml
+++ b/build/azDevOps/azure/nuget-packages-api-vars.yml
@@ -2,7 +2,7 @@ variables:
   - name: region
     value: westeurope
   - name: company
-    value: amido
+    value: ensono
   - name: project
     value: stacks
   - name: domain
@@ -16,13 +16,13 @@ variables:
   - name: create_release
     value: true
   - name: github_release_service_connection
-    value: GitHubReleases
+    value: ensonostacks
   - name: github_org
     value: $(company)
 
   # Nuget information
   - name: nuget_connection
-    value: NuGetAmidoStacksServiceConnection
+    value: NuGetStacksServiceConnection
 
   # SelfConfig
   # If you haven't specified source_repo at cli runtime please ensure you replace it here

--- a/build/azDevOps/azure/nuget-packages-api.yml
+++ b/build/azDevOps/azure/nuget-packages-api.yml
@@ -24,35 +24,15 @@ resources:
   repositories:
     - repository: templates
       type: github
-      name: amido/stacks-pipeline-templates
+      name: Ensono/stacks-pipeline-templates
       ref: refs/tags/v2.0.6
-      endpoint: amidostacks
-
-  # containers:
-  #   - container: sonar_scanner
-  #     image: amidostacks/ci-sonarscanner:0.0.3
-  #   - container: k8s_deploy
-  #     image: amidostacks/ci-k8s:0.0.12
-  #   - container: terraform_custom
-  #     image: amidostacks/ci-tf:1.1.6
+      endpoint: ensonostacks
 
 variables:
   - template: nuget-packages-api-vars.yml
 
 stages:
   - stage: Build
-    # variables:
-    #   - group: amido-stacks-infra-credentials-nonprod
-    #   - group: stacks-credentials-nonprod-kv
-    #   - group: amido-stacks-webapp
-    #   - name: azure_tenant_id
-    #     value: "$(azure-tenant-id)"
-    #   - name: azure_subscription_id
-    #     value: "$(azure-subscription-id)"
-    #   - name: azure_client_id
-    #     value: "$(azure-client-id)"
-    #   - name: azure_client_secret
-    #     value: "$(azure-client-secret)"
     jobs:
       - job: AppBuild
         pool:
@@ -103,9 +83,7 @@ stages:
       - Build
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'), eq(variables['create_release'], 'true'))
     variables:
-      - group: amido-stacks-infra-credentials-prod
-      # Note: Following group is not used, because it contains api key information and we are using a service connection in this pipeline.
-      # - group: amido-stacks-nuget-credentials
+      - group: stacks-infra-credentials-prod
 
     jobs:
       - job: CreateGitHubRelease

--- a/deploy/k8s/aws/base_api-deploy.yml
+++ b/deploy/k8s/aws/base_api-deploy.yml
@@ -9,29 +9,15 @@ metadata:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=120 # resolved 502 error while deployment "https://www.tessian.com/blog/how-to-fix-http-502-errors/"
-    alb.ingress.kubernetes.io/certificate-arn: ${k8s_ingress_cert_arn}
-    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
-    alb.ingress.kubernetes.io/healthcheck-port: traffic-port
-    alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
-    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
-    alb.ingress.kubernetes.io/healthy-threshold-count: "2"
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}, {"HTTP":80}]'
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/success-codes: "200"
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/unhealthy-threshold-count: "2"
-    external-dns.alpha.kubernetes.io/hostname: ${dns_pointer}
     app.kubernetes.io/instance: ${project}-${app_name}
     app.kubernetes.io/version: ${version}
     applicationId: ${project}/${app_name}
     applicationName: ${project}-${app_name}
     customerID: ${company}
-    kubernetes.io/ingress.class: alb
     owner: ${company}/${project}
     projectID: ${project}
     version: ${version}
@@ -40,17 +26,19 @@ metadata:
     app.kubernetes.io/name: ${resource_def_name}
     app.kubernetes.io/part-of: ${project}
     environment: ${environment}
-  finalizers:
-  - ingress.k8s.aws/resources
   name: ${resource_def_name}
   namespace: ${namespace}
 spec:
+  ingressClassName: nginx
   rules:
-    - http:
+    - host: ${dns_pointer}
+      http:
         paths:
           - backend:
-              serviceName: ${resource_def_name}
-              servicePort: 80
+              service:
+                name: ${resource_def_name}
+                port: 
+                  number: 80
             path: ${k8s_app_route}/*
             pathType: ImplementationSpecific
 ---

--- a/deploy/k8s/aws/base_api-deploy.yml
+++ b/deploy/k8s/aws/base_api-deploy.yml
@@ -39,8 +39,11 @@ spec:
                 name: ${resource_def_name}
                 port: 
                   number: 80
-            path: ${k8s_app_route}/*
+            path: ${k8s_app_route}
             pathType: ImplementationSpecific
+  tls:
+    - hosts:
+        - ${dns_pointer}
 ---
 
 apiVersion: v1

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -46,10 +46,10 @@ pipelines:
     - task: infra:init
     - task: deploy:templater
       depends_on: infra:init
-    - task: deploy:helm
+    - task: deploy:kubernetes
       depends_on: deploy:templater
     - task: debug:sleep
-      depends_on: deploy:helm
+      depends_on: deploy:kubernetes
       variables:
         - sleep: 30
     - task: deploy:functional_tests


### PR DESCRIPTION
#### 📲 What

Update NuGet publish pipeline and variable for the Ensono Azure DevOps instance.

#### 🤔 Why
		
The legacy Amido pipeline is broken and will no longer publish NuGet packages.
		
#### 🛠 How
		
- Update repositories from amido to ensono
- Update service connections
- Replace Helm deploy with Kubernetes manifest (AWS not currently supported by the Helm chart)
- Update ingress for AWS

#### 👀 Evidence
		
		 
#### 🕵️ How to test


#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
