### PR TITLE
chore: Remove LangVersion property from csproj files

### DIFF
--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/xxAMIDOxx.xxSTACKSxx.API.ComponentTests.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/xxAMIDOxx.xxSTACKSxx.API.ComponentTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/xxAMIDOxx.xxSTACKSxx.API.ComponentTests.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/xxAMIDOxx.xxSTACKSxx.API.ComponentTests.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+	  <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.API.UnitTests/xxAMIDOxx.xxSTACKSxx.API.UnitTests.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.API.UnitTests/xxAMIDOxx.xxSTACKSxx.API.UnitTests.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+	    <IsTestProject>true</IsTestProject>
         <Nullable>enable</Nullable>
 
         <IsPackable>false</IsPackable>

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.API/xxAMIDOxx.xxSTACKSxx.API.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.API/xxAMIDOxx.xxSTACKSxx.API.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers/xxAMIDOxx.xxSTACKSxx.Application.CommandHandlers.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\xxAMIDOxx.xxSTACKSxx.Application.Integration\xxAMIDOxx.xxSTACKSxx.Application.Integration.csproj" />

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Application.Integration/xxAMIDOxx.xxSTACKSxx.Application.Integration.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Application.Integration/xxAMIDOxx.xxSTACKSxx.Application.Integration.csproj
@@ -1,8 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Application.QueryHandlers/xxAMIDOxx.xxSTACKSxx.Application.QueryHandlers.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Application.QueryHandlers/xxAMIDOxx.xxSTACKSxx.Application.QueryHandlers.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+	  <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.CQRS/xxAMIDOxx.xxSTACKSxx.CQRS.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.CQRS/xxAMIDOxx.xxSTACKSxx.CQRS.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Common.UnitTests/xxAMIDOxx.xxSTACKSxx.Common.UnitTests.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Common.UnitTests/xxAMIDOxx.xxSTACKSxx.Common.UnitTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Common.UnitTests/xxAMIDOxx.xxSTACKSxx.Common.UnitTests.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Common.UnitTests/xxAMIDOxx.xxSTACKSxx.Common.UnitTests.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+	  <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Common/xxAMIDOxx.xxSTACKSxx.Common.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Common/xxAMIDOxx.xxSTACKSxx.Common.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+	  <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Domain/xxAMIDOxx.xxSTACKSxx.Domain.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Domain/xxAMIDOxx.xxSTACKSxx.Domain.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+	  <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+	  <IsTestProject>true</IsTestProject>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
+++ b/src/cqrs/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/xxAMIDOxx.xxSTACKSxx.Infrastructure.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/func-aeh-listener/src/functions/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
+++ b/src/func-aeh-listener/src/functions/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/func-aeh-listener/src/functions/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
+++ b/src/func-aeh-listener/src/functions/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+	  <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/func-asb-listener/src/functions/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
+++ b/src/func-asb-listener/src/functions/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/func-asb-listener/src/functions/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
+++ b/src/func-asb-listener/src/functions/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+	  <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/func-cosmosdb-worker/src/functions/xxAMIDOxx.xxSTACKSxx.Worker.UnitTests/xxAMIDOxx.xxSTACKSxx.Worker.UnitTests.csproj
+++ b/src/func-cosmosdb-worker/src/functions/xxAMIDOxx.xxSTACKSxx.Worker.UnitTests/xxAMIDOxx.xxSTACKSxx.Worker.UnitTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/func-cosmosdb-worker/src/functions/xxAMIDOxx.xxSTACKSxx.Worker.UnitTests/xxAMIDOxx.xxSTACKSxx.Worker.UnitTests.csproj
+++ b/src/func-cosmosdb-worker/src/functions/xxAMIDOxx.xxSTACKSxx.Worker.UnitTests/xxAMIDOxx.xxSTACKSxx.Worker.UnitTests.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+	  <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Configuration.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Configuration.Tests.csproj
+++ b/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Configuration.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Configuration.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
+	  <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Core.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Core.Tests.csproj
+++ b/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Core.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Core.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
+	  <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Data.Documents.CosmosDB.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Data.Documents.CosmosDB.Tests.csproj
+++ b/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Data.Documents.CosmosDB.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Data.Documents.CosmosDB.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
+	  <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.DynamoDB.Tests/xxAMIDOxx.xxSTACKSxx.Shared.DynamoDB.Tests.csproj
+++ b/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.DynamoDB.Tests/xxAMIDOxx.xxSTACKSxx.Shared.DynamoDB.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+	  <IsTestProject>true</IsTestProject>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.DynamoDB/xxAMIDOxx.xxSTACKSxx.Shared.DynamoDB.csproj
+++ b/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.DynamoDB/xxAMIDOxx.xxSTACKSxx.Shared.DynamoDB.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
-	<LangVersion>10.0</LangVersion>
     <Description>DynamoDB package for common features used throughout the projects.</Description>
     <Company>Amido</Company>
 	<PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.AWS.SNS.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.AWS.SNS.Tests.csproj
+++ b/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.AWS.SNS.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.AWS.SNS.Tests.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+	      <IsTestProject>true</IsTestProject>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.AWS.SNS/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.AWS.SNS.csproj
+++ b/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.AWS.SNS/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.AWS.SNS.csproj
@@ -4,7 +4,6 @@
         <TargetFramework>net6.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <LangVersion>10.0</LangVersion>
         <Description>AWS SNS package for common features used throughout the projects.</Description>
         <Company>Amido</Company>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.Azure.EventHub.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.Azure.EventHub.Tests.csproj
+++ b/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.Azure.EventHub.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.Azure.EventHub.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-
+	  <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Tests.csproj
+++ b/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Tests.csproj
+++ b/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+	  <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Testing.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Testing.Tests.csproj
+++ b/src/shared/xxAMIDOxx.xxSTACKSxx.Shared.Testing.Tests/xxAMIDOxx.xxSTACKSxx.Shared.Testing.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net6.0</TargetFrameworks>
+	  <IsTestProject>true</IsTestProject>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/simple-api/src/api/xxAMIDOxx.xxSTACKSxx.API.Models/xxAMIDOxx.xxSTACKSxx.API.Models.csproj
+++ b/src/simple-api/src/api/xxAMIDOxx.xxSTACKSxx.API.Models/xxAMIDOxx.xxSTACKSxx.API.Models.csproj
@@ -1,8 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 

--- a/src/simple-api/src/api/xxAMIDOxx.xxSTACKSxx.API.UnitTests/xxAMIDOxx.xxSTACKSxx.API.UnitTests.csproj
+++ b/src/simple-api/src/api/xxAMIDOxx.xxSTACKSxx.API.UnitTests/xxAMIDOxx.xxSTACKSxx.API.UnitTests.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
         <IsTestProject>true</IsTestProject>
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/src/simple-api/src/api/xxAMIDOxx.xxSTACKSxx.API/xxAMIDOxx.xxSTACKSxx.API.csproj
+++ b/src/simple-api/src/api/xxAMIDOxx.xxSTACKSxx.API/xxAMIDOxx.xxSTACKSxx.API.csproj
@@ -2,10 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10.0</LangVersion>
-    </PropertyGroup>
-
-    <PropertyGroup>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <NoWarn>$(NoWarn);1591</NoWarn>
     </PropertyGroup>


### PR DESCRIPTION
This pull request involves updating multiple project files to remove the `LangVersion` property, which previously specified C# language version 10.0. This change affects various components across the codebase, including API, application command handlers, integration, query handlers, unit tests, and shared libraries.