### PR TITLE
fix: 7713 - remove rogue references to Stacks.Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ Now that you have your cloud services all set, you can point the API project to 
 }
 ```
 
-The `SecurityKeySecret` and `ConnectionStringSecret` sections are needed because of our use of the `Ensono.Stacks.Configuration` package. `COSMOSDB_KEY`, `SERVICEBUS_CONNECTIONSTRING`, `EVENTHUB_CONNECTIONSTRING` or `TOPIC_ARN` have to be set before you can run the project. If you want to debug the solution with VSCode you usually have a `launch.json` file. In that file there's an `env` section where you can put environment variables for the current session.
+The `SecurityKeySecret` and `ConnectionStringSecret` sections are needed because of our use of references to secrets in configuration. `COSMOSDB_KEY`, `SERVICEBUS_CONNECTIONSTRING`, `EVENTHUB_CONNECTIONSTRING` or `TOPIC_ARN` have to be set before you can run the project. If you want to debug the solution with VSCode you usually have a `launch.json` file. In that file there's an `env` section where you can put environment variables for the current session.
 
 ```json
 "env": {

--- a/asciidoc/quickstart/web_api_cqrs/configure_project.adoc
+++ b/asciidoc/quickstart/web_api_cqrs/configure_project.adoc
@@ -22,7 +22,7 @@ keywords:
 
 == Configuring the project
 
-All security sensitive information is passed as a secret in our configuration. We have a library called https://github.com/Ensono/stacks-dotnet-packages-configuration[Ensono.Stacks.Configuration] that reads secrets from the environment before the application starts and makes the needed substitutions in the configuration files.
+All security sensitive information is passed as a secret in our configuration.
 
 === Configuring Cosmos DB
 

--- a/docs/quickstart/web_api_cqrs/configure_project_netcore.md
+++ b/docs/quickstart/web_api_cqrs/configure_project_netcore.md
@@ -23,7 +23,7 @@ keywords:
 
 ## Configuring the project
 
-All security sensitive information is passed as a secret in our configuration. We have a library called [Ensono.Stacks.Configuration](https://github.com/Ensono/stacks-dotnet-packages-configuration) that reads secrets from the environment before the application starts and makes the needed substitutions in the configuration files.
+All security sensitive information is passed as a secret in our configuration.
 
 ### Configuring Cosmos DB
 

--- a/src/background-worker/.template.config/template.json
+++ b/src/background-worker/.template.config/template.json
@@ -42,8 +42,6 @@
                 ".gitignore",
                 ".gitattributes",
                 "src/background-worker/**",
-                "src/shared/xxENSONOxx.xxSTACKSxx.Shared.Configuration/**",
-                "src/shared/xxENSONOxx.xxSTACKSxx.Shared.Configuration.Tests/**",
                 "src/shared/xxENSONOxx.xxSTACKSxx.Shared.Core/**",
                 "src/shared/xxENSONOxx.xxSTACKSxx.Shared.Core.Tests/**",
                 "src/shared/xxENSONOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus/**",


### PR DESCRIPTION
#### 📲 What

Removed some references in documentation and also template.json that shouldn't exist anymore

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
