### PR TITLE
Adjust binding names to match Azure environment variables.

### DIFF
--- a/deploy/azure/app/function/function.tf
+++ b/deploy/azure/app/function/function.tf
@@ -31,7 +31,7 @@ resource "azurerm_linux_function_app" "function" {
   functions_extension_version = var.az_function_extension_version
 
   app_settings = {
-    COSMOSDB_COLLECTION_NAME       = var.cosmosdb_collection_name
+    COSMOSDB_CONTAINER_NAME        = var.cosmosdb_collection_name
     COSMOSDB_CONNECTIONSTRING      = var.cosmosdb_connection_string
     COSMOSDB_DATABASE_NAME         = var.cosmosdb_database_name
     COSMOSDB_LEASE_COLLECTION_NAME = var.cosmosdb_lease_collection_name

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/CosmosDbChangeFeedListener.cs
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/CosmosDbChangeFeedListener.cs
@@ -10,10 +10,10 @@ public class CosmosDbChangeFeedListener(
 {
     [Function(Constants.FunctionNames.CosmosDbChangeFeedListener)]
     public void Run([CosmosDBTrigger(
-        databaseName: "%COSMOSDB_DATABASENAME%",
-        containerName: "%COSMOSDB_CONTAINERNAME%",
-        Connection = "COSMOSDB_CONNECTIONSTRING",
-        LeaseContainerName = "%COSMOSDB_LEASECOLLECTIONNAME%",
+        databaseName: "%COSMOSDB_DATABASE_NAME%",
+        containerName: "%COSMOSDB_CONTAINER_NAME%",
+        Connection = "COSMOSDB_CONNECTION_STRING",
+        LeaseContainerName = "leases",
         CreateLeaseContainerIfNotExists  = true)]IReadOnlyList<CosmosDbChangeFeedEvent>? input)
     {
         if (input is { Count: > 0 })

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/CosmosDbChangeFeedListener.cs
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/CosmosDbChangeFeedListener.cs
@@ -12,8 +12,8 @@ public class CosmosDbChangeFeedListener(
     public void Run([CosmosDBTrigger(
         databaseName: "%COSMOSDB_DATABASE_NAME%",
         containerName: "%COSMOSDB_CONTAINER_NAME%",
-        Connection = "COSMOSDB_CONNECTION_STRING",
-        LeaseContainerName = "leases",
+        Connection = "COSMOSDB_CONNECTIONSTRING",
+        LeaseContainerName = "%COSMOSDB_LEASE_COLLECTION_NAME%",
         CreateLeaseContainerIfNotExists  = true)]IReadOnlyList<CosmosDbChangeFeedEvent>? input)
     {
         if (input is { Count: > 0 })


### PR DESCRIPTION
## Adjust binding names to match Azure environment variables.

### 📲 What

This changes adjusts the names fo the bindings for the CosmosDB worker's input trigger.

### 🤔 Why

The binding names will match the environment variable names in Azure

### 🛠 How

Simple string adjustments in the trigger.

### 👀 Evidence

See changes in file for the adjustments.

### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
