### PR TITLE
Remove Service Bus Configuration from appsettings.

### DIFF
--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/appsettings.json
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/appsettings.json
@@ -1,11 +1,10 @@
-﻿{
+{
     "OTEL_EXPORTER_OTLP_ENDPOINT": "REPLACE_ME",
     "APPLICATIONINSIGHTS_CONNECTION_STRING": "InstrumentationKey=REPLACE_ME",
 	"ServiceBusConfiguration": {
 		"Sender": {
 			"Topics": [
 				{
-					"Name": "sbt-menu-events",
 					"ConnectionStringSecret": {
 						"Identifier": "SERVICEBUS_CONNECTIONSTRING",
 						"Source": "Environment"


### PR DESCRIPTION
## Remove Service Bus Configuration from appsettings.

### 📲 What

Remove the Service Bus configuration from appsettings.

### 🤔 Why

Settings will not be included so that they can be set as environment variables.

### 🛠 How

Removed configuration from appsettings file

### 👀 Evidence

See attached file change
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
