### PR TITLE
8304 - Upgrade System.Text.Json to patched version 8.05 to mitigate vulnerability

### DIFF
--- a/src/cqrs/src/api/xxENSONOxx.xxSTACKSxx.Infrastructure/xxENSONOxx.xxSTACKSxx.Infrastructure.csproj
+++ b/src/cqrs/src/api/xxENSONOxx.xxSTACKSxx.Infrastructure/xxENSONOxx.xxSTACKSxx.Infrastructure.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
+    <!-- Transient packeges:  Referenced explicity due to vulnerabilities in lower versions. -->
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="8.0.8" />
     <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.7.400.5" />
   </ItemGroup>

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/xxENSONOxx.xxSTACKSxx.Worker.csproj
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/xxENSONOxx.xxSTACKSxx.Worker.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
 
     <!-- Transient packeges:  Referenced explicity due to vulnerabilities in lower versions. -->
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/simple-api/src/api/xxENSONOxx.xxSTACKSxx.API.UnitTests/xxENSONOxx.xxSTACKSxx.API.UnitTests.csproj
+++ b/src/simple-api/src/api/xxENSONOxx.xxSTACKSxx.API.UnitTests/xxENSONOxx.xxSTACKSxx.API.UnitTests.csproj
@@ -16,6 +16,8 @@
         <PackageReference Include="System.DirectoryServices.Protocols" Version="8.0.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
         <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+        <!-- Transient packeges:  Referenced explicity due to vulnerabilities in lower versions. -->
+        <PackageReference Include="System.Text.Json" Version="8.0.5" />
         <PackageReference Include="TestStack.BDDfy" Version="4.3.2" />
         <PackageReference Include="xunit" Version="2.9.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">


### PR DESCRIPTION
#### 📲 What

Upgrade System.Text.Json to patched version 8.05 to mitigate vulnerability

#### 🤔 Why

In System.Text.Json 6.0.x and 8.0.x, applications which deserialize input to a model with an [ExtensionData] property can be vulnerable to an algorithmic complexity attack resulting in Denial of Service.

#### 🛠 How

Upgrade System.Text.Json to patched version 8.05 to mitigate vulnerability

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
