### PR TITLE
CosmosDB Azure Function:  Adjustments for consistency 

### DIFF
--- a/scripts/expected-trees/Cosmos.Worker.tree
+++ b/scripts/expected-trees/Cosmos.Worker.tree
@@ -74,13 +74,14 @@
 │   │           │   │   └── ChangeFeedListenerFixture.cs
 │   │           │   └── GlobalUsings.cs
 │   │           ├── Cosmos.Worker.Worker.UnitTests
-│   │           │   ├── ChangeFeedListenerEventUnitTests.cs
-│   │           │   ├── ChangeFeedListenerTests.cs
 │   │           │   ├── Cosmos.Worker.Worker.UnitTests.csproj
 │   │           │   ├── Doubles
 │   │           │   │   └── MockLogger.cs
-│   │           │   ├── EventCodeUnitTests.cs
-│   │           │   └── GlobalUsings.cs
+│   │           │   ├── GlobalUsings.cs
+│   │           │   └── Tests
+│   │           │       ├── ChangeFeedListenerEventUnitTests.cs
+│   │           │       ├── ChangeFeedListenerTests.cs
+│   │           │       └── EventCodeUnitTests.cs
 │   │           ├── Cosmos.Worker.Worker.sln
 │   │           └── Dockerfile
 │   └── shared

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.ComponentTests/Fixtures/ChangeFeedListenerFixture.cs
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.ComponentTests/Fixtures/ChangeFeedListenerFixture.cs
@@ -5,9 +5,9 @@ namespace xxENSONOxx.xxSTACKSxx.Worker.ComponentTests.Fixtures;
 
 public class ChangeFeedListenerFixture
 {
-    private const string DocumentsChangesMessage = "Documents modified";
+    private const string DocumentsChangesMessage = "Documents modified:";
     private const string DocumentReadMessage = "Document read. Id:";
-    
+
     private readonly Random random;
     private readonly IFixture autoFixture;
     private readonly IApplicationEventPublisher applicationEventPublisher;
@@ -34,7 +34,7 @@ public class ChangeFeedListenerFixture
 
     public void GivenCosmosDbTriggerReceivesEvents()
     {
-        changeFeedEventCount = random.Next(1, 11); 
+        changeFeedEventCount = random.Next(1, 11);
         changeFeedEvents = autoFixture.CreateMany<CosmosDbChangeFeedEvent>(changeFeedEventCount).ToList();
     }
 

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.UnitTests/Doubles/MockLogger.cs
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.UnitTests/Doubles/MockLogger.cs
@@ -10,9 +10,8 @@ public class MockLogger<T> : ILogger<T>
 
     public bool IsEnabled(LogLevel logLevel) => true;
 
-    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
     {
         LogMessages.Add(formatter(state, exception));
     }
 }
-

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.UnitTests/Tests/ChangeFeedListenerEventUnitTests.cs
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.UnitTests/Tests/ChangeFeedListenerEventUnitTests.cs
@@ -1,6 +1,6 @@
 using xxENSONOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Operations;
 
-namespace xxENSONOxx.xxSTACKSxx.Worker.UnitTests;
+namespace xxENSONOxx.xxSTACKSxx.Worker.UnitTests.Tests;
 
 public class ChangeFeedListenerEventUnitTests
 {
@@ -20,14 +20,11 @@ public class ChangeFeedListenerEventUnitTests
         var changeFeedEvent = new CosmosDbChangeFeedEvent(operationCode, correlationId, entityId, eTag);
 
         // Assert
-        changeFeedEvent.Should().BeEquivalentTo(new
-        {
-            OperationCode = operationCode,
-            CorrelationId = correlationId,
-            EntityId = entityId,
-            ETag = eTag,
-            EventCode = (int)EventCode.EntityUpdated
-        });
+        changeFeedEvent.EventCode.Should().Be((int)EventCode.EntityUpdated);
+        changeFeedEvent.OperationCode.Should().Be(operationCode);
+        changeFeedEvent.CorrelationId.Should().Be(correlationId);
+        changeFeedEvent.EntityId.Should().Be(entityId);
+        changeFeedEvent.ETag.Should().Be(eTag);
     }
 
 
@@ -35,13 +32,7 @@ public class ChangeFeedListenerEventUnitTests
     public void Constructor_ShouldAssignPropertiesCorrectly_WhenInitializedWithOperationContext()
     {
         // Arrange
-        var operationCode = autoFixture.Create<int>();
-        var correlationId = autoFixture.Create<Guid>();
-        var context = autoFixture.Freeze<IOperationContext>();
-
-        context.OperationCode.Returns(operationCode);
-        context.CorrelationId.Returns(correlationId);
-
+        var context = autoFixture.Create<IOperationContext>();
         var entityId = autoFixture.Create<Guid>();
         var eTag = autoFixture.Create<string>();
 
@@ -49,13 +40,10 @@ public class ChangeFeedListenerEventUnitTests
         var changeFeedEvent = new CosmosDbChangeFeedEvent(context, entityId, eTag);
 
         // Assert
-        changeFeedEvent.Should().BeEquivalentTo(new
-        {
-            OperationCode = operationCode,
-            CorrelationId = correlationId,
-            EntityId = entityId,
-            ETag = eTag,
-            EventCode = (int)EventCode.EntityUpdated
-        });
+        changeFeedEvent.EventCode.Should().Be((int)EventCode.EntityUpdated);
+        changeFeedEvent.OperationCode.Should().Be(context.OperationCode);
+        changeFeedEvent.CorrelationId.Should().Be(context.CorrelationId);
+        changeFeedEvent.EntityId.Should().Be(entityId);
+        changeFeedEvent.ETag.Should().Be(eTag);
     }
 }

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.UnitTests/Tests/ChangeFeedListenerTests.cs
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.UnitTests/Tests/ChangeFeedListenerTests.cs
@@ -6,7 +6,7 @@ namespace xxENSONOxx.xxSTACKSxx.Worker.UnitTests.Tests;
 [Trait("TestType", "UnitTests")]
 public class ChangeFeedListenerUnitTests
 {
-    private const string DocumentsChangesMessage = "Documents modified";
+    private const string DocumentsChangesMessage = "Documents modified:";
     private const string DocumentReadMessage = "Document read. Id:";
 
     private readonly Random random;

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.UnitTests/Tests/ChangeFeedListenerTests.cs
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.UnitTests/Tests/ChangeFeedListenerTests.cs
@@ -1,7 +1,7 @@
 using xxENSONOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Abstractions.ApplicationEvents;
 using xxENSONOxx.xxSTACKSxx.Worker.UnitTests.Doubles;
 
-namespace xxENSONOxx.xxSTACKSxx.Worker.UnitTests;
+namespace xxENSONOxx.xxSTACKSxx.Worker.UnitTests.Tests;
 
 [Trait("TestType", "UnitTests")]
 public class ChangeFeedListenerUnitTests

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.UnitTests/Tests/EventCodeUnitTests.cs
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.UnitTests/Tests/EventCodeUnitTests.cs
@@ -1,4 +1,4 @@
-namespace xxENSONOxx.xxSTACKSxx.Worker.UnitTests;
+namespace xxENSONOxx.xxSTACKSxx.Worker.UnitTests.Tests;
 
 [Trait("TestType", "UnitTests")]
 public sealed class EventCodeUnitTests

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.UnitTests/xxENSONOxx.xxSTACKSxx.Worker.UnitTests.csproj
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker.UnitTests/xxENSONOxx.xxSTACKSxx.Worker.UnitTests.csproj
@@ -10,12 +10,12 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
-    <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/CosmosDbChangeFeedEvent.cs
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/CosmosDbChangeFeedEvent.cs
@@ -1,4 +1,4 @@
-using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using xxENSONOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Abstractions.ApplicationEvents;
 using xxENSONOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Operations;
 

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/CosmosDbChangeFeedListener.cs
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/CosmosDbChangeFeedListener.cs
@@ -18,10 +18,10 @@ public class CosmosDbChangeFeedListener(
     {
         if (input is { Count: > 0 })
         {
-            logger.LogInformation("Documents modified " + input.Count);
+            logger.LogInformation("Documents modified: {Count}", input.Count);
             foreach (var changedItem in input)
             {
-                logger.LogInformation("Document read. Id: " + changedItem.EntityId);
+                logger.LogInformation("Document read. Id: {EntityId}", changedItem.EntityId);
 
                 var cosmosDbEvent = new CosmosDbChangeFeedEvent(
                     operationCode: changedItem.OperationCode,


### PR DESCRIPTION
# CosmosDB Azure Function:  Adjustments for consistency 

## 📲 What

Adjustments to the Cosmos DB worker to make it more consistent with other projects in the overall solution: -

* Unit Tests assertion style matches other projects.
* Unit tests grouped into a Tests folder
* Newtonsoft.Json package used instead of System.Text.Jsoin to align with Service Bus library.

## 🤔 Why

After working on the Service Bus Worker I noticed some inconsistencies with the PR I made for this request, so these few adjustments make the fucntion project more consistent with the other projects.

## 🛠 How

Simple adjustmtments to test assertions and System.Text.Json replaced with Newtonsoft.Json.

## 👀 Evidence

The screenshot belwo shows the tests still pass after these adjutments,

![image](https://github.com/user-attachments/assets/72386f8d-37d5-45ab-aa1f-ca5f521dd186)
