### PR TITLE
Fix:  CosmosDbChangeFeedEvent deserialization error.

### DIFF
--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/CosmosDbChangeFeedEvent.cs
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/CosmosDbChangeFeedEvent.cs
@@ -1,25 +1,36 @@
-using Newtonsoft.Json;
+//using Newtonsoft.Json;
+
+using System.Text.Json.Serialization;
 using xxENSONOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Abstractions.ApplicationEvents;
 using xxENSONOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Operations;
 
 namespace xxENSONOxx.xxSTACKSxx.Worker;
 
-[method: JsonConstructor]
-public sealed class CosmosDbChangeFeedEvent(int operationCode, Guid correlationId, Guid entityId, string eTag)
-                  : IApplicationEvent
+
+public class CosmosDbChangeFeedEvent : IApplicationEvent
 {
+    [JsonConstructor]
+    public CosmosDbChangeFeedEvent(int operationCode, Guid correlationId, Guid entityId, string eTag)
+    {
+        OperationCode = operationCode;
+        CorrelationId = correlationId;
+        EntityId = entityId;
+        ETag = eTag;
+    }
+
     public CosmosDbChangeFeedEvent(IOperationContext context, Guid entityId, string eTag)
          : this(context.OperationCode, context.CorrelationId, entityId, eTag)
     {
     }
 
+
     public int EventCode => (int)Worker.EventCode.EntityUpdated;
 
-    public int OperationCode { get; } = operationCode;
+    public int OperationCode { get; }
 
-    public Guid CorrelationId { get; } = correlationId;
+    public Guid CorrelationId { get; }
 
-    public Guid EntityId { get; } = entityId;
+    public Guid EntityId { get; }
 
-    public string ETag { get; } = eTag;
+    public string ETag { get; }
 }

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/CosmosDbChangeFeedEvent.cs
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/CosmosDbChangeFeedEvent.cs
@@ -1,36 +1,25 @@
-//using Newtonsoft.Json;
-
 using System.Text.Json.Serialization;
 using xxENSONOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Abstractions.ApplicationEvents;
 using xxENSONOxx.xxSTACKSxx.Shared.Messaging.Azure.ServiceBus.Operations;
 
 namespace xxENSONOxx.xxSTACKSxx.Worker;
 
-
-public class CosmosDbChangeFeedEvent : IApplicationEvent
+[method: JsonConstructor]
+public sealed class CosmosDbChangeFeedEvent(int operationCode, Guid correlationId, Guid entityId, string eTag)
+                  : IApplicationEvent
 {
-    [JsonConstructor]
-    public CosmosDbChangeFeedEvent(int operationCode, Guid correlationId, Guid entityId, string eTag)
-    {
-        OperationCode = operationCode;
-        CorrelationId = correlationId;
-        EntityId = entityId;
-        ETag = eTag;
-    }
-
     public CosmosDbChangeFeedEvent(IOperationContext context, Guid entityId, string eTag)
          : this(context.OperationCode, context.CorrelationId, entityId, eTag)
     {
     }
 
-
     public int EventCode => (int)Worker.EventCode.EntityUpdated;
 
-    public int OperationCode { get; }
+    public int OperationCode { get; } = operationCode;
 
-    public Guid CorrelationId { get; }
+    public Guid CorrelationId { get; } = correlationId;
 
-    public Guid EntityId { get; }
+    public Guid EntityId { get; } = entityId;
 
-    public string ETag { get; }
+    public string ETag { get; } = eTag;
 }

--- a/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/xxENSONOxx.xxSTACKSxx.Worker.csproj
+++ b/src/func-cosmosdb-worker/src/functions/xxENSONOxx.xxSTACKSxx.Worker/xxENSONOxx.xxSTACKSxx.Worker.csproj
@@ -21,9 +21,6 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.9.0" />
-
-    <!-- Transient packeges:  Referenced explicity due to vulnerabilities in lower versions. -->
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Fix: CosmosDbChangeFeedEvent deserialization error

### 📲 What

Fixes a deserialisation error in Azure Function with a CosmosDB listener, caused by Newtonsoft's JsonConstructor attribute being ignored.

### 🤔 Why

When the JsonConstructor attibute is ignored, the CosmosDB changefeed binding is failing to deserialise the incomming event, becasue it doesn't  know which constructor to use.

### 🛠 How

Adjusted the Newtonsoft.Json.JsonConstructor to the System.Text.Json.Serialization.JsonConstructor which the Azure Fuction will use to find the correct constructor.

### 👀 Evidence

The screenshot below shows output from the function when a change feed event is raised, showing that deserialisation has run as expected.

![image](https://github.com/user-attachments/assets/320264f9-0e5e-4d5d-b5bc-793df9bdf7af)

