### PR TITLE
fix: move functional tests to separate step

### DIFF
--- a/.github/workflows/ci-cqrs.yml
+++ b/.github/workflows/ci-cqrs.yml
@@ -40,7 +40,6 @@ env:
   K8S_APP_ROUTE: "/api/menu"
   FUNCTIONAL_TESTS_RUN_DIR: ${{ github.workspace }}/tests
   FUNCTIONAL_TESTS_ARTEFACT_NAME: tests
-  TEMPLATER_FILE: "build/deployment_list.ps1"
 jobs:
   Build:
     runs-on: ubuntu-latest
@@ -225,8 +224,22 @@ jobs:
           # K8S Additional Deploy-Templater temporary var substitutions (should be from TF outputs and per env)
           DOCKER_REGISTRY: "${{ secrets.AWS_ACCOUNT_ID }}.${{ env.ECR_DOMAIN}}"
           DNS_BASE_DOMAIN: "nonprod.aws.stacks.ensono.com"
+          TEMPLATER_FILE: "build/deployment_list.ps1"
+
+      - name: TaskCTL Functional Tests
+        run: taskctl functional_tests
+        env:
+          ENV_NAME: dev
+          # AWS Environmental Config
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.REGION }}
+          # Terraform Backend Configuration (for outputs)
+          TF_FILE_LOCATION: deploy/aws/app/kube
+          TF_BACKEND_ARGS: region=${{ secrets.AWS_TF_STATE_REGION }},access_key=${{ secrets.AWS_ACCESS_KEY_ID }},secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }},bucket=${{ secrets.AWS_TF_STATE_BUCKET }},key=${{ env.AWS_TF_STATE_KEY }},dynamodb_table=${{ secrets.AWS_TF_STATE_DYNAMOTABLE }},encrypt=${{ secrets.AWS_TF_STATE_ENCRYPTION }}
           # Functional Test Configuration
           FUNCTIONAL_TESTS_RUN_DIR: /app/tests # Must match RELATIVE path from repo root that artefact is downloaded to.
+          TEMPLATER_FILE: "${{ env.FUNCTIONAL_TESTS_RUN_DIR }}/templater.ps1"
           BaseUrl: "https://dev-${{ env.DOMAIN }}.nonprod.aws.stacks.ensono.com/api/menu/"
 
       - name: "Dev: Functional Test Report"
@@ -337,8 +350,22 @@ jobs:
           # K8S Additional Deploy-Templater temporary var substitutions (should be from TF outputs and per env)
           DOCKER_REGISTRY: "${{ secrets.AWS_ACCOUNT_ID }}.${{ env.ECR_DOMAIN}}"
           DNS_BASE_DOMAIN: "prod.aws.stacks.ensono.com"
+          TEMPLATER_FILE: "build/deployment_list.ps1"
+
+      - name: TaskCTL Functional Tests
+        run: taskctl functional_tests
+        env:
+          ENV_NAME: prod
+          # AWS Environmental Config
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.REGION }}
+          # Terraform Backend Configuration (for outputs)
+          TF_FILE_LOCATION: deploy/aws/app/kube
+          TF_BACKEND_ARGS: region=${{ secrets.AWS_TF_STATE_REGION }},access_key=${{ secrets.AWS_ACCESS_KEY_ID }},secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }},bucket=${{ secrets.AWS_TF_STATE_BUCKET }},key=${{ env.AWS_TF_STATE_KEY }},dynamodb_table=${{ secrets.AWS_TF_STATE_DYNAMOTABLE }},encrypt=${{ secrets.AWS_TF_STATE_ENCRYPTION }}
           # Functional Test Configuration
           FUNCTIONAL_TESTS_RUN_DIR: /app/tests # Must match RELATIVE path from repo root that artefact is downloaded to.
+          TEMPLATER_FILE: "${{ env.FUNCTIONAL_TESTS_RUN_DIR }}/templater.ps1"
           BaseUrl: "https://prod-${{ env.DOMAIN }}.prod.aws.stacks.ensono.com/api/menu/"
 
       - name: "Prod: Functional Test Report"

--- a/.github/workflows/ci-simple-api.yml
+++ b/.github/workflows/ci-simple-api.yml
@@ -40,7 +40,6 @@ env:
   K8S_APP_ROUTE: "/api/menu"
   FUNCTIONAL_TESTS_RUN_DIR: ${{ github.workspace }}/tests
   FUNCTIONAL_TESTS_ARTEFACT_NAME: tests
-  TEMPLATER_FILE: "build/deployment_list.ps1"
 jobs:
   Build:
     runs-on: ubuntu-latest
@@ -225,8 +224,22 @@ jobs:
           # K8S Additional Deploy-Templater temporary var substitutions (should be from TF outputs and per env)
           DOCKER_REGISTRY: "${{ secrets.AWS_ACCOUNT_ID }}.${{ env.ECR_DOMAIN}}"
           DNS_BASE_DOMAIN: "nonprod.aws.stacks.ensono.com"
+          TEMPLATER_FILE: "build/deployment_list.ps1"
+
+      - name: TaskCTL Functional Tests
+        run: taskctl functional_tests
+        env:
+          ENV_NAME: dev
+          # AWS Environmental Config
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.REGION }}
+          # Terraform Backend Configuration (for outputs)
+          TF_FILE_LOCATION: deploy/aws/app/kube
+          TF_BACKEND_ARGS: region=${{ secrets.AWS_TF_STATE_REGION }},access_key=${{ secrets.AWS_ACCESS_KEY_ID }},secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }},bucket=${{ secrets.AWS_TF_STATE_BUCKET }},key=${{ env.AWS_TF_STATE_KEY }},dynamodb_table=${{ secrets.AWS_TF_STATE_DYNAMOTABLE }},encrypt=${{ secrets.AWS_TF_STATE_ENCRYPTION }}
           # Functional Test Configuration
           FUNCTIONAL_TESTS_RUN_DIR: /app/tests # Must match RELATIVE path from repo root that artefact is downloaded to.
+          TEMPLATER_FILE: "${{ env.FUNCTIONAL_TESTS_RUN_DIR }}/templater.ps1"
           BaseUrl: "https://dev-${{ env.DOMAIN }}.nonprod.aws.stacks.ensono.com/api/menu/"
 
       - name: "Dev: Functional Test Report"
@@ -337,8 +350,22 @@ jobs:
           # K8S Additional Deploy-Templater temporary var substitutions (should be from TF outputs and per env)
           DOCKER_REGISTRY: "${{ secrets.AWS_ACCOUNT_ID }}.${{ env.ECR_DOMAIN}}"
           DNS_BASE_DOMAIN: "prod.aws.stacks.ensono.com"
+          TEMPLATER_FILE: "build/deployment_list.ps1"
+
+      - name: TaskCTL Functional Tests
+        run: taskctl functional_tests
+        env:
+          ENV_NAME: prod
+          # AWS Environmental Config
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.REGION }}
+          # Terraform Backend Configuration (for outputs)
+          TF_FILE_LOCATION: deploy/aws/app/kube
+          TF_BACKEND_ARGS: region=${{ secrets.AWS_TF_STATE_REGION }},access_key=${{ secrets.AWS_ACCESS_KEY_ID }},secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }},bucket=${{ secrets.AWS_TF_STATE_BUCKET }},key=${{ env.AWS_TF_STATE_KEY }},dynamodb_table=${{ secrets.AWS_TF_STATE_DYNAMOTABLE }},encrypt=${{ secrets.AWS_TF_STATE_ENCRYPTION }}
           # Functional Test Configuration
           FUNCTIONAL_TESTS_RUN_DIR: /app/tests # Must match RELATIVE path from repo root that artefact is downloaded to.
+          TEMPLATER_FILE: "${{ env.FUNCTIONAL_TESTS_RUN_DIR }}/templater.ps1"
           BaseUrl: "https://prod-${{ env.DOMAIN }}.prod.aws.stacks.ensono.com/api/menu/"
 
       - name: "Prod: Functional Test Report"

--- a/build/azDevOps/azure/ci.yml
+++ b/build/azDevOps/azure/ci.yml
@@ -287,8 +287,6 @@ stages:
                     ENV_NAME: $(Environment.ShortName)
                     DOMAIN: ${{ variables.domain }}
                     TEMPLATER_FILE: build/deployment_list.ps1
-                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR) # Must match RELATIVE path from repo root that artefact is downloaded to.
-                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
                     # Invoke-KubeCTL control variables
                     NAMESPACE: $(namespace)
                     RESOURCE_DEF_NAME: $(resource_def_name)
@@ -303,6 +301,25 @@ stages:
                     HELM_CHART_FILE: $(helm_chart_file)
                     INGRESS_ENABLED: $(ingress_enabled)
                     SERVICEBUS_TYPE: ${{ variables.servicebus_type }}
+
+                - task: Bash@3
+                  displayName: "Taskctl: Functional Tests"
+                  condition: and(succeeded(), eq(variables.run_functional_tests, true))
+                  inputs:
+                    targetType: inline
+                    script: taskctl functional_tests
+                  env:
+                    # Azure Authentication
+                    CLOUD_PROVIDER: "$(cloud_provider)"
+                    # Terraform Backend Configuration (used for Terraform Outputs)
+                    TF_STATE_CONTAINER: $(tf_state_container)
+                    TF_STATE_KEY: $(tf_state_key)
+                    TF_STATE_RG: $(tf_state_rg)
+                    TF_STATE_STORAGE: $(tf_state_storage)
+                    TF_BACKEND_ARGS: "key=$(TF_STATE_KEY),storage_account_name=$(TF_STATE_STORAGE),resource_group_name=$(TF_STATE_RG),container_name=$(TF_STATE_CONTAINER),subscription_id=$(ARM_SUBSCRIPTION_ID),tenant_id=$(ARM_TENANT_ID),client_id=$(ARM_CLIENT_ID),client_secret=$(ARM_CLIENT_SECRET)"
+                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR)
+                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
+                    TEMPLATER_FILE: $(FUNCTIONAL_TESTS_RUN_DIR)/templater.ps1
 
                 - task: PublishPipelineArtifact@1
                   displayName: "Upload: Helm Values"
@@ -491,8 +508,6 @@ stages:
                     ENV_NAME: $(Environment.ShortName)
                     DOMAIN: ${{ variables.domain }}
                     TEMPLATER_FILE: build/deployment_list.ps1
-                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR) # Must match RELATIVE path from repo root that artefact is downloaded to.
-                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
                     # Invoke-KubeCTL control variables
                     NAMESPACE: $(namespace)
                     RESOURCE_DEF_NAME: $(resource_def_name)
@@ -507,6 +522,25 @@ stages:
                     HELM_CHART_FILEPATH: $(helm_chart_file)
                     INGRESS_ENABLED: $(ingress_enabled)
                     SERVICEBUS_TYPE: ${{ variables.servicebus_type }}
+
+                - task: Bash@3
+                  displayName: "Taskctl: Functional Tests"
+                  condition: and(succeeded(), eq(variables.run_functional_tests, true))
+                  inputs:
+                    targetType: inline
+                    script: taskctl functional_tests
+                  env:
+                    # Azure Authentication
+                    CLOUD_PROVIDER: "$(cloud_provider)"
+                    # Terraform Backend Configuration (used for Terraform Outputs)
+                    TF_STATE_CONTAINER: $(tf_state_container)
+                    TF_STATE_KEY: $(tf_state_key)
+                    TF_STATE_RG: $(tf_state_rg)
+                    TF_STATE_STORAGE: $(tf_state_storage)
+                    TF_BACKEND_ARGS: "key=$(TF_STATE_KEY),storage_account_name=$(TF_STATE_STORAGE),resource_group_name=$(TF_STATE_RG),container_name=$(TF_STATE_CONTAINER),subscription_id=$(ARM_SUBSCRIPTION_ID),tenant_id=$(ARM_TENANT_ID),client_id=$(ARM_CLIENT_ID),client_secret=$(ARM_CLIENT_SECRET)"
+                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR)
+                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
+                    TEMPLATER_FILE: $(FUNCTIONAL_TESTS_RUN_DIR)/templater.ps1
 
                 - task: PublishPipelineArtifact@1
                   displayName: "Upload: Helm Values"

--- a/build/azDevOps/azure/ensono/ci-background-worker.yml
+++ b/build/azDevOps/azure/ensono/ci-background-worker.yml
@@ -294,8 +294,6 @@ stages:
                     ENV_NAME: $(Environment.ShortName)
                     DOMAIN: ${{ variables.domain }}
                     TEMPLATER_FILE: build/deployment_list.ps1
-                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR) # Must match RELATIVE path from repo root that artefact is downloaded to.
-                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
                     # Invoke-KubeCTL control variables
                     NAMESPACE: $(namespace)
                     RESOURCE_DEF_NAME: $(resource_def_name)
@@ -310,6 +308,25 @@ stages:
                     HELM_CHART_FILE: $(helm_chart_file)
                     INGRESS_ENABLED: $(ingress_enabled)
                     SERVICEBUS_TYPE: ${{ variables.servicebus_type }}
+
+                - task: Bash@3
+                  displayName: "Taskctl: Functional Tests"
+                  condition: and(succeeded(), eq(variables.run_functional_tests, true))
+                  inputs:
+                    targetType: inline
+                    script: taskctl functional_tests
+                  env:
+                    # Azure Authentication
+                    CLOUD_PROVIDER: "$(cloud_provider)"
+                    # Terraform Backend Configuration (used for Terraform Outputs)
+                    TF_STATE_CONTAINER: $(tf_state_container)
+                    TF_STATE_KEY: $(tf_state_key)
+                    TF_STATE_RG: $(tf_state_rg)
+                    TF_STATE_STORAGE: $(tf_state_storage)
+                    TF_BACKEND_ARGS: "key=$(TF_STATE_KEY),storage_account_name=$(TF_STATE_STORAGE),resource_group_name=$(TF_STATE_RG),container_name=$(TF_STATE_CONTAINER),subscription_id=$(ARM_SUBSCRIPTION_ID),tenant_id=$(ARM_TENANT_ID),client_id=$(ARM_CLIENT_ID),client_secret=$(ARM_CLIENT_SECRET)"
+                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR)
+                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
+                    TEMPLATER_FILE: $(FUNCTIONAL_TESTS_RUN_DIR)/templater.ps1
 
                 - task: PublishPipelineArtifact@1
                   displayName: "Upload: Helm Values"
@@ -498,8 +515,6 @@ stages:
                     ENV_NAME: $(Environment.ShortName)
                     DOMAIN: ${{ variables.domain }}
                     TEMPLATER_FILE: build/deployment_list.ps1
-                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR) # Must match RELATIVE path from repo root that artefact is downloaded to.
-                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
                     # Invoke-KubeCTL control variables
                     NAMESPACE: $(namespace)
                     RESOURCE_DEF_NAME: $(resource_def_name)
@@ -514,6 +529,25 @@ stages:
                     HELM_CHART_FILEPATH: $(helm_chart_file)
                     INGRESS_ENABLED: $(ingress_enabled)
                     SERVICEBUS_TYPE: ${{ variables.servicebus_type }}
+
+                - task: Bash@3
+                  displayName: "Taskctl: Functional Tests"
+                  condition: and(succeeded(), eq(variables.run_functional_tests, true))
+                  inputs:
+                    targetType: inline
+                    script: taskctl functional_tests
+                  env:
+                    # Azure Authentication
+                    CLOUD_PROVIDER: "$(cloud_provider)"
+                    # Terraform Backend Configuration (used for Terraform Outputs)
+                    TF_STATE_CONTAINER: $(tf_state_container)
+                    TF_STATE_KEY: $(tf_state_key)
+                    TF_STATE_RG: $(tf_state_rg)
+                    TF_STATE_STORAGE: $(tf_state_storage)
+                    TF_BACKEND_ARGS: "key=$(TF_STATE_KEY),storage_account_name=$(TF_STATE_STORAGE),resource_group_name=$(TF_STATE_RG),container_name=$(TF_STATE_CONTAINER),subscription_id=$(ARM_SUBSCRIPTION_ID),tenant_id=$(ARM_TENANT_ID),client_id=$(ARM_CLIENT_ID),client_secret=$(ARM_CLIENT_SECRET)"
+                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR)
+                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
+                    TEMPLATER_FILE: $(FUNCTIONAL_TESTS_RUN_DIR)/templater.ps1
 
                 - task: PublishPipelineArtifact@1
                   displayName: "Upload: Helm Values"

--- a/build/azDevOps/azure/ensono/ci-cqrs.yml
+++ b/build/azDevOps/azure/ensono/ci-cqrs.yml
@@ -294,8 +294,6 @@ stages:
                     ENV_NAME: $(Environment.ShortName)
                     DOMAIN: ${{ variables.domain }}
                     TEMPLATER_FILE: build/deployment_list.ps1
-                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR) # Must match RELATIVE path from repo root that artefact is downloaded to.
-                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
                     # Invoke-KubeCTL control variables
                     NAMESPACE: $(namespace)
                     RESOURCE_DEF_NAME: $(resource_def_name)
@@ -310,6 +308,25 @@ stages:
                     HELM_CHART_FILE: $(helm_chart_file)
                     INGRESS_ENABLED: $(ingress_enabled)
                     SERVICEBUS_TYPE: ${{ variables.servicebus_type }}
+
+                - task: Bash@3
+                  displayName: "Taskctl: Functional Tests"
+                  condition: and(succeeded(), eq(variables.run_functional_tests, true))
+                  inputs:
+                    targetType: inline
+                    script: taskctl functional_tests
+                  env:
+                    # Azure Authentication
+                    CLOUD_PROVIDER: "$(cloud_provider)"
+                    # Terraform Backend Configuration (used for Terraform Outputs)
+                    TF_STATE_CONTAINER: $(tf_state_container)
+                    TF_STATE_KEY: $(tf_state_key)
+                    TF_STATE_RG: $(tf_state_rg)
+                    TF_STATE_STORAGE: $(tf_state_storage)
+                    TF_BACKEND_ARGS: "key=$(TF_STATE_KEY),storage_account_name=$(TF_STATE_STORAGE),resource_group_name=$(TF_STATE_RG),container_name=$(TF_STATE_CONTAINER),subscription_id=$(ARM_SUBSCRIPTION_ID),tenant_id=$(ARM_TENANT_ID),client_id=$(ARM_CLIENT_ID),client_secret=$(ARM_CLIENT_SECRET)"
+                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR)
+                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
+                    TEMPLATER_FILE: $(FUNCTIONAL_TESTS_RUN_DIR)/templater.ps1
 
                 - task: PublishPipelineArtifact@1
                   displayName: "Upload: Helm Values"
@@ -497,8 +514,6 @@ stages:
                     ENV_NAME: $(Environment.ShortName)
                     DOMAIN: ${{ variables.domain }}
                     TEMPLATER_FILE: build/deployment_list.ps1
-                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR) # Must match RELATIVE path from repo root that artefact is downloaded to.
-                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
                     # Invoke-KubeCTL control variables
                     NAMESPACE: $(namespace)
                     RESOURCE_DEF_NAME: $(resource_def_name)
@@ -513,6 +528,25 @@ stages:
                     HELM_CHART_FILEPATH: $(helm_chart_file)
                     INGRESS_ENABLED: $(ingress_enabled)
                     SERVICEBUS_TYPE: ${{ variables.servicebus_type }}
+
+                - task: Bash@3
+                  displayName: "Taskctl: Functional Tests"
+                  condition: and(succeeded(), eq(variables.run_functional_tests, true))
+                  inputs:
+                    targetType: inline
+                    script: taskctl functional_tests
+                  env:
+                    # Azure Authentication
+                    CLOUD_PROVIDER: "$(cloud_provider)"
+                    # Terraform Backend Configuration (used for Terraform Outputs)
+                    TF_STATE_CONTAINER: $(tf_state_container)
+                    TF_STATE_KEY: $(tf_state_key)
+                    TF_STATE_RG: $(tf_state_rg)
+                    TF_STATE_STORAGE: $(tf_state_storage)
+                    TF_BACKEND_ARGS: "key=$(TF_STATE_KEY),storage_account_name=$(TF_STATE_STORAGE),resource_group_name=$(TF_STATE_RG),container_name=$(TF_STATE_CONTAINER),subscription_id=$(ARM_SUBSCRIPTION_ID),tenant_id=$(ARM_TENANT_ID),client_id=$(ARM_CLIENT_ID),client_secret=$(ARM_CLIENT_SECRET)"
+                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR)
+                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
+                    TEMPLATER_FILE: $(FUNCTIONAL_TESTS_RUN_DIR)/templater.ps1
 
                 - task: PublishPipelineArtifact@1
                   displayName: "Upload: Helm Values"

--- a/build/azDevOps/azure/ensono/ci-simple-api.yml
+++ b/build/azDevOps/azure/ensono/ci-simple-api.yml
@@ -294,8 +294,6 @@ stages:
                     ENV_NAME: $(Environment.ShortName)
                     DOMAIN: ${{ variables.domain }}
                     TEMPLATER_FILE: build/deployment_list.ps1
-                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR) # Must match RELATIVE path from repo root that artefact is downloaded to.
-                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
                     # Invoke-KubeCTL control variables
                     NAMESPACE: $(namespace)
                     RESOURCE_DEF_NAME: $(resource_def_name)
@@ -310,6 +308,25 @@ stages:
                     HELM_CHART_FILE: $(helm_chart_file)
                     INGRESS_ENABLED: $(ingress_enabled)
                     SERVICEBUS_TYPE: ${{ variables.servicebus_type }}
+
+                - task: Bash@3
+                  displayName: "Taskctl: Functional Tests"
+                  condition: and(succeeded(), eq(variables.run_functional_tests, true))
+                  inputs:
+                    targetType: inline
+                    script: taskctl functional_tests
+                  env:
+                    # Azure Authentication
+                    CLOUD_PROVIDER: "$(cloud_provider)"
+                    # Terraform Backend Configuration (used for Terraform Outputs)
+                    TF_STATE_CONTAINER: $(tf_state_container)
+                    TF_STATE_KEY: $(tf_state_key)
+                    TF_STATE_RG: $(tf_state_rg)
+                    TF_STATE_STORAGE: $(tf_state_storage)
+                    TF_BACKEND_ARGS: "key=$(TF_STATE_KEY),storage_account_name=$(TF_STATE_STORAGE),resource_group_name=$(TF_STATE_RG),container_name=$(TF_STATE_CONTAINER),subscription_id=$(ARM_SUBSCRIPTION_ID),tenant_id=$(ARM_TENANT_ID),client_id=$(ARM_CLIENT_ID),client_secret=$(ARM_CLIENT_SECRET)"
+                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR)
+                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
+                    TEMPLATER_FILE: $(FUNCTIONAL_TESTS_RUN_DIR)/templater.ps1
 
                 - task: PublishPipelineArtifact@1
                   displayName: "Upload: Helm Values"
@@ -498,8 +515,6 @@ stages:
                     ENV_NAME: $(Environment.ShortName)
                     DOMAIN: ${{ variables.domain }}
                     TEMPLATER_FILE: build/deployment_list.ps1
-                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR) # Must match RELATIVE path from repo root that artefact is downloaded to.
-                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
                     # Invoke-KubeCTL control variables
                     NAMESPACE: $(namespace)
                     RESOURCE_DEF_NAME: $(resource_def_name)
@@ -514,6 +529,25 @@ stages:
                     HELM_CHART_FILEPATH: $(helm_chart_file)
                     INGRESS_ENABLED: $(ingress_enabled)
                     SERVICEBUS_TYPE: ${{ variables.servicebus_type }}
+
+                - task: Bash@3
+                  displayName: "Taskctl: Functional Tests"
+                  condition: and(succeeded(), eq(variables.run_functional_tests, true))
+                  inputs:
+                    targetType: inline
+                    script: taskctl functional_tests
+                  env:
+                    # Azure Authentication
+                    CLOUD_PROVIDER: "$(cloud_provider)"
+                    # Terraform Backend Configuration (used for Terraform Outputs)
+                    TF_STATE_CONTAINER: $(tf_state_container)
+                    TF_STATE_KEY: $(tf_state_key)
+                    TF_STATE_RG: $(tf_state_rg)
+                    TF_STATE_STORAGE: $(tf_state_storage)
+                    TF_BACKEND_ARGS: "key=$(TF_STATE_KEY),storage_account_name=$(TF_STATE_STORAGE),resource_group_name=$(TF_STATE_RG),container_name=$(TF_STATE_CONTAINER),subscription_id=$(ARM_SUBSCRIPTION_ID),tenant_id=$(ARM_TENANT_ID),client_id=$(ARM_CLIENT_ID),client_secret=$(ARM_CLIENT_SECRET)"
+                    FUNCTIONAL_TESTS_RUN_DIR: $(FUNCTIONAL_TESTS_RUN_DIR)
+                    BaseUrl: $(FUNCTIONAL_TEST_BASEURL)
+                    TEMPLATER_FILE: $(FUNCTIONAL_TESTS_RUN_DIR)/templater.ps1
 
                 - task: PublishPipelineArtifact@1
                   displayName: "Upload: Helm Values"

--- a/build/github/aws/ci.yml
+++ b/build/github/aws/ci.yml
@@ -40,7 +40,6 @@ env:
   K8S_APP_ROUTE: "/api/menu"
   FUNCTIONAL_TESTS_RUN_DIR: ${{ github.workspace }}/tests
   FUNCTIONAL_TESTS_ARTEFACT_NAME: tests
-  TEMPLATER_FILE: "build/deployment_list.ps1"
 jobs:
   Build:
     runs-on: ubuntu-latest
@@ -225,8 +224,22 @@ jobs:
           # K8S Additional Deploy-Templater temporary var substitutions (should be from TF outputs and per env)
           DOCKER_REGISTRY: "${{ secrets.AWS_ACCOUNT_ID }}.${{ env.ECR_DOMAIN}}"
           DNS_BASE_DOMAIN: "replaceme" # i.e. "nonprod.aws.stacks.ensono.com"
+          TEMPLATER_FILE: "build/deployment_list.ps1"
+
+      - name: TaskCTL Functional Tests
+        run: taskctl functional_tests
+        env:
+          ENV_NAME: dev
+          # AWS Environmental Config
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.REGION }}
+          # Terraform Backend Configuration (for outputs)
+          TF_FILE_LOCATION: deploy/aws/app/kube
+          TF_BACKEND_ARGS: region=${{ secrets.AWS_TF_STATE_REGION }},access_key=${{ secrets.AWS_ACCESS_KEY_ID }},secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }},bucket=${{ secrets.AWS_TF_STATE_BUCKET }},key=${{ env.AWS_TF_STATE_KEY }},dynamodb_table=${{ secrets.AWS_TF_STATE_DYNAMOTABLE }},encrypt=${{ secrets.AWS_TF_STATE_ENCRYPTION }}
           # Functional Test Configuration
           FUNCTIONAL_TESTS_RUN_DIR: /app/tests # Must match RELATIVE path from repo root that artefact is downloaded to.
+          TEMPLATER_FILE: "${{ env.FUNCTIONAL_TESTS_RUN_DIR }}/templater.ps1"
           BaseUrl: "replaceme" # i.e. "https://dev-netcore-api.nonprod.aws.stacks.ensono.com/api/menu/"
 
       - name: "Dev: ${{ env.DOMAIN }} Functional Test Report"
@@ -337,8 +350,22 @@ jobs:
           # K8S Additional Deploy-Templater temporary var substitutions (should be from TF outputs and per env)
           DOCKER_REGISTRY: "${{ secrets.AWS_ACCOUNT_ID }}.${{ env.ECR_DOMAIN}}"
           DNS_BASE_DOMAIN: "replaceme" # i.e. "prod.aws.stacks.ensono.com"
+          TEMPLATER_FILE: "build/deployment_list.ps1"
+
+      - name: TaskCTL Functional Tests
+        run: taskctl functional_tests
+        env:
+          ENV_NAME: prod
+          # AWS Environmental Config
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ env.REGION }}
+          # Terraform Backend Configuration (for outputs)
+          TF_FILE_LOCATION: deploy/aws/app/kube
+          TF_BACKEND_ARGS: region=${{ secrets.AWS_TF_STATE_REGION }},access_key=${{ secrets.AWS_ACCESS_KEY_ID }},secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }},bucket=${{ secrets.AWS_TF_STATE_BUCKET }},key=${{ env.AWS_TF_STATE_KEY }},dynamodb_table=${{ secrets.AWS_TF_STATE_DYNAMOTABLE }},encrypt=${{ secrets.AWS_TF_STATE_ENCRYPTION }}
           # Functional Test Configuration
           FUNCTIONAL_TESTS_RUN_DIR: /app/tests # Must match RELATIVE path from repo root that artefact is downloaded to.
+          TEMPLATER_FILE: "${{ env.FUNCTIONAL_TESTS_RUN_DIR }}/templater.ps1"
           BaseUrl: "replaceme" # i.e. "https://prod-netcore-api.prod.aws.stacks.ensono.com/api/menu/"
 
       - name: "Prod: ${{ env.DOMAIN }} Functional Test Report"

--- a/scripts/expected-trees/Cqrs.AllTheThings.tree
+++ b/scripts/expected-trees/Cqrs.AllTheThings.tree
@@ -462,7 +462,8 @@
 │   │               │   │       ├── UpdateItemById.cs
 │   │               │   │       └── UpdateMenuById.cs
 │   │               │   └── appsettings.json
-│   │               └── Cqrs.AllTheThings.API.FunctionalTests.sln
+│   │               ├── Cqrs.AllTheThings.API.FunctionalTests.sln
+│   │               └── templater.ps1
 │   └── shared
 │       ├── .editorconfig
 │       ├── Cqrs.AllTheThings.Shared.Messaging.Azure.ServiceBus

--- a/scripts/expected-trees/Cqrs.Dynamo.tree
+++ b/scripts/expected-trees/Cqrs.Dynamo.tree
@@ -415,7 +415,8 @@
 │   │               │   │       ├── UpdateItemById.cs
 │   │               │   │       └── UpdateMenuById.cs
 │   │               │   └── appsettings.json
-│   │               └── Cqrs.Dynamo.API.FunctionalTests.sln
+│   │               ├── Cqrs.Dynamo.API.FunctionalTests.sln
+│   │               └── templater.ps1
 │   └── shared
 │       ├── .editorconfig
 │       ├── Cqrs.Dynamo.Shared.Messaging.Azure.ServiceBus

--- a/scripts/expected-trees/Cqrs.ServiceBus.tree
+++ b/scripts/expected-trees/Cqrs.ServiceBus.tree
@@ -422,7 +422,8 @@
 │   │               │   │       ├── UpdateItemById.cs
 │   │               │   │       └── UpdateMenuById.cs
 │   │               │   └── appsettings.json
-│   │               └── Cqrs.ServiceBus.API.FunctionalTests.sln
+│   │               ├── Cqrs.ServiceBus.API.FunctionalTests.sln
+│   │               └── templater.ps1
 │   └── shared
 │       ├── .editorconfig
 │       ├── Cqrs.ServiceBus.Shared.Messaging.Azure.ServiceBus

--- a/scripts/expected-trees/Cqrs.Sns.tree
+++ b/scripts/expected-trees/Cqrs.Sns.tree
@@ -405,7 +405,8 @@
 │   │               │   │       ├── UpdateItemById.cs
 │   │               │   │       └── UpdateMenuById.cs
 │   │               │   └── appsettings.json
-│   │               └── Cqrs.Sns.API.FunctionalTests.sln
+│   │               ├── Cqrs.Sns.API.FunctionalTests.sln
+│   │               └── templater.ps1
 │   └── shared
 │       ├── .editorconfig
 │       ├── Cqrs.Sns.Shared.Messaging.Azure.ServiceBus

--- a/scripts/expected-trees/Cqrs.tree
+++ b/scripts/expected-trees/Cqrs.tree
@@ -466,7 +466,8 @@
 │   │               │   │       ├── UpdateItemById.cs
 │   │               │   │       └── UpdateMenuById.cs
 │   │               │   └── appsettings.json
-│   │               └── Cqrs.API.FunctionalTests.sln
+│   │               ├── Cqrs.API.FunctionalTests.sln
+│   │               └── templater.ps1
 │   └── shared
 │       ├── .editorconfig
 │       ├── Cqrs.Shared.Messaging.Azure.ServiceBus

--- a/scripts/expected-trees/Simple.Api.AWS.tree
+++ b/scripts/expected-trees/Simple.Api.AWS.tree
@@ -231,7 +231,8 @@
 │               │   │   │       ├── UpdateItemById.cs
 │               │   │   │       └── UpdateMenuById.cs
 │               │   │   └── appsettings.json
-│               │   └── Simple.Api.AWS.API.FunctionalTests.sln
+│               │   ├── Simple.Api.AWS.API.FunctionalTests.sln
+│               │   └── templater.ps1
 │               └── README.md
 ├── stackscli.yml
 ├── taskctl.yaml

--- a/scripts/expected-trees/Simple.Api.Azure.tree
+++ b/scripts/expected-trees/Simple.Api.Azure.tree
@@ -254,7 +254,8 @@
 │               │   │   │       ├── UpdateItemById.cs
 │               │   │   │       └── UpdateMenuById.cs
 │               │   │   └── appsettings.json
-│               │   └── Simple.Api.Azure.API.FunctionalTests.sln
+│               │   ├── Simple.Api.Azure.API.FunctionalTests.sln
+│               │   └── templater.ps1
 │               └── README.md
 ├── stackscli.yml
 ├── taskctl.yaml

--- a/scripts/expected-trees/Simple.Api.tree
+++ b/scripts/expected-trees/Simple.Api.tree
@@ -298,7 +298,8 @@
 │               │   │   │       ├── UpdateItemById.cs
 │               │   │   │       └── UpdateMenuById.cs
 │               │   │   └── appsettings.json
-│               │   └── Simple.Api.API.FunctionalTests.sln
+│               │   ├── Simple.Api.API.FunctionalTests.sln
+│               │   └── templater.ps1
 │               └── README.md
 ├── stackscli.yml
 ├── taskctl.yaml

--- a/src/cqrs/src/tests/Functional/templater.ps1
+++ b/src/cqrs/src/tests/Functional/templater.ps1
@@ -1,0 +1,8 @@
+# This script is used to generate the appsettings.json files for the functional tests in the pipeline.
+@(
+  @{
+    displayName = "FunctionalTests"
+    template = "tests/xxENSONOxx.xxSTACKSxx.API.FunctionalTests/appsettings.json"
+    vars = @{}
+  }
+)

--- a/src/simple-api/src/tests/Functional/templater.ps1
+++ b/src/simple-api/src/tests/Functional/templater.ps1
@@ -1,0 +1,8 @@
+# This script is used to generate the appsettings.json files for the functional tests in the pipeline.
+@(
+  @{
+    displayName = "FunctionalTests"
+    template = "tests/xxENSONOxx.xxSTACKSxx.API.FunctionalTests/appsettings.json"
+    vars = @{}
+  }
+)

--- a/taskctl.yaml
+++ b/taskctl.yaml
@@ -57,5 +57,3 @@ pipelines:
       depends_on: infra:init
     - task: deploy:helm
       depends_on: deploy:templater
-    - task: deploy:functional_tests
-      depends_on: deploy:helm


### PR DESCRIPTION
#### 📲 What

Moves functional tests to a separate step from the deployment.

#### 🤔 Why

So different templater files can be used for deployment and functional tests.

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
