### PR TITLE
fix: use taskctl for generating expected trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ All templates from this repository come as part of the [Stacks Dotnet NuGet pack
 
 ### Generating the expected directory trees
 
-The template outputs are validated during testing using the directory tree files in the `scripts/expected-trees` directory. When files are added or removed from the template the expected directory trees will need to be updated. This can be done using the `test-templates.ps1` script with the `-GenerateExpectedTrees` parameter (`pwsh test-templates.ps1 -GenerateExpectedTrees`)
+**Pre-Requisites** 
+- [Docker](https://www.docker.com/products/docker-desktop/)
+- [Taskctl](https://github.com/Ensono/taskctl)
+
+The template outputs are validated during testing using the directory tree files in the `scripts/expected-trees` directory. When files are added or removed from the template the expected directory trees will need to be updated. This can be done using the Taskctl task (`taskctl test:generate_trees`)
 
 ### Template usage
 

--- a/build/taskctl/tasks.yaml
+++ b/build/taskctl/tasks.yaml
@@ -130,6 +130,23 @@ tasks:
     command:
       - Invoke-DotNet -Coverage -target /app/coverage
 
+  test:generate_trees:
+    context: powershell-dotnet
+    description: Generate expected trees for comparison
+    command:
+      - |
+        apt-get install tree -y
+        pwsh scripts/test-templates.ps1 --GenerateExpectedTrees
+
+  test:templates:
+    context: powershell-dotnet
+    description: Compare directory against expected tree
+    command:
+      - |
+        apt-get install tree -y
+        Invoke-DotNet -Custom -arguments "workload install aspire"
+        pwsh scripts/test-templates.ps1
+
   # Compilation tasks
   build:container:
     context: powershell

--- a/scripts/compare-directory-files.ps1
+++ b/scripts/compare-directory-files.ps1
@@ -14,7 +14,7 @@ if (-Not (Test-Path $Directory)) {
 }
 
 $inputStructure = Get-Content -Path $InputFile
-$generatedStructure = Push-Location -Path $Directory && tree -a -I 'bin|obj' --noreport && Pop-Location
+$generatedStructure = Push-Location -Path $Directory && tree -a --charset utf-8 -I 'bin|obj' --noreport && Pop-Location
 
 # Compare the two structures
 $differences = Compare-Object -ReferenceObject $inputStructure -DifferenceObject $generatedStructure

--- a/scripts/test-templates.ps1
+++ b/scripts/test-templates.ps1
@@ -22,7 +22,7 @@ if (!([string]::IsNullOrEmpty($Branch))) {
     git clone -b $Branch git@github.com:Ensono/stacks-dotnet.git $StacksDotnetDirectory
 }
 
-if (!$GenerateExpectedTrees) {
+if (!$GenerateExpectedTrees -And ([string]::IsNullOrEmpty($Template))) {
     # Change directory to the simple-api project and run the tests
     Push-Location -Path "$StacksDotnetDirectory/src/simple-api/src/api" && dotnet restore && dotnet test --filter TestType!=IntegrationTests && Pop-Location
 
@@ -170,7 +170,7 @@ $projects | ForEach-Object {
         if ($GenerateExpectedTrees) {
             Write-Output "Generating expected directory tree for $($project.Name)"
             Push-Location -Path ($project.Name)
-            tree -a --noreport > $PSScriptRoot/expected-trees/$($project.Name).tree
+            tree -a --charset utf-8 --noreport > $PSScriptRoot/expected-trees/$($project.Name).tree
             Pop-Location
         }
     }


### PR DESCRIPTION
#### 📲 What

Use Taskctl for generating expected trees and running test templates.

#### 🤔 Why

The `tree` command is different for Windows and Linux so using Docker via Taskctl will keep the output consistent.

#### 🛠 How

- Add tasks for generating trees and running the test-templates

#### 🕵️ How to test

`taskctl test:generate_trees`

`taskctl test:templates`

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
