### PR TITLE
Updated the template vars to include the component

### DIFF
--- a/build/azDevOps/azure/ci-aca-background-worker-vars.yml
+++ b/build/azDevOps/azure/ci-aca-background-worker-vars.yml
@@ -6,11 +6,11 @@ variables:
   - name: project
     value: {{ .Project.Name }}
   - name: domain
-    value: {{ .Input.Business.Domain }}
+    value: {{ .Input.Business.Domain }}-background-worker
   - name: self_repo
     value: {{ .Project.Name }}
   - name: self_generic_name
-    value: $(company)-$(domain)
+    value: $(company)-$(domain)-background-worker
 
   # Azure DevOps Group containing the SONAR_TOKEN secret
   - group: replaceme
@@ -128,7 +128,7 @@ variables:
 
   # Versioning
   - name: version_major
-    value: 7
+    value: 0
   - name: version_minor
     value: 0
   - name: version_revision

--- a/build/azDevOps/azure/ci-aca-cqrs-vars.yml
+++ b/build/azDevOps/azure/ci-aca-cqrs-vars.yml
@@ -6,11 +6,11 @@ variables:
   - name: project
     value: {{ .Project.Name }}
   - name: domain
-    value: {{ .Input.Business.Domain }}
+    value: {{ .Input.Business.Domain }}-cqrs
   - name: self_repo
     value: {{ .Project.Name }}
   - name: self_generic_name
-    value: $(company)-$(domain)
+    value: $(company)-$(domain)-cqrs
 
   # Azure DevOps Group containing the SONAR_TOKEN secret
   - group: replaceme
@@ -128,7 +128,7 @@ variables:
 
   # Versioning
   - name: version_major
-    value: 7
+    value: 0
   - name: version_minor
     value: 0
   - name: version_revision

--- a/build/azDevOps/azure/ci-aca-simple-api-vars.yml
+++ b/build/azDevOps/azure/ci-aca-simple-api-vars.yml
@@ -112,7 +112,7 @@ variables:
   - name: docker_image_tag
     value: $(version_number)-$(Build.SourceBranchName)
   - name: docker_image_name
-    value: $(self_generic_name)s
+    value: $(self_generic_name)
 
   # DNS Configuration
   - name: create_dns_record
@@ -128,7 +128,7 @@ variables:
 
   # Versioning
   - name: version_major
-    value: 7
+    value: 0
   - name: version_minor
     value: 0
   - name: version_revision

--- a/stackscli.yml
+++ b/stackscli.yml
@@ -34,7 +34,7 @@ init:
       desc: Install stacks templates from the repo directory
     - action: cmd
       cmd: dotnet
-      args: new stacks-{{ .Project.Framework.Option }} -n {{ .Input.Business.Company }}.{{ .Input.Business.Domain }} --domain {{ .Input.Business.Domain }} --cloudProvider {{ .Input.Cloud.Platform }} --cicdProvider {{ .Input.Pipeline }} -o {{ .Project.Directory.WorkingDir }}  {{if .Project.Framework.DeploymentMode}} --deploymentMode {{ .Project.Framework.DeploymentMode }}  {{end}}
+      args: new stacks-{{ .Project.Framework.Option }} -n {{ .Input.Business.Company }} --domain {{ .Input.Business.Domain }} --cloudProvider {{ .Input.Cloud.Platform }} --cicdProvider {{ .Input.Pipeline }} -o {{ .Project.Directory.WorkingDir }}  {{if .Project.Framework.DeploymentMode}} --deploymentMode {{ .Project.Framework.DeploymentMode }}  {{end}}
       desc: Create a project using the stacks template
     - action: cmd
       cmd: dotnet


### PR DESCRIPTION
#### 📲 What

Updated the template vars for aca to include the component

Updated the stackscli.yml to remove the domain from the namespace without this the solution will fail to compile because the type is mistaken for a namespace.

`dotnet new stacks-cqrs -n Bal.Tech --domain Tech --cloudProvider Azure --cicdProvider AZDO ` will return this error when building, 
error CS0118: 'Tech' is a namespace but is used like a type 

However if I put remove the domain field e.g. Tech from namespace,
`dotnet new stacks-cqrs -n Bal --domain Tech --cloudProvider Azure --cicdProvider AZDO `
it works fine.

#### 🤔 Why

For the vars change. its consistent with the other pipelines 

#### 🛠 How
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
