### PR TITLE
chore: comment out generated tree comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,6 @@ All templates from this repository come as part of the [Stacks Dotnet NuGet pack
 - `stacks-az-func-aeh-listener`. Template containing an Azure Function project with a single function that has a Event Hub trigger. The function receives the message and deserializes it.
 - `stacks-az-func-cosmosdb-worker`. Azure Function containing a CosmosDb change feed trigger. Upon a CosmosDb event, the worker reads it and publishes a message to Service Bus.
 
-### Generating the expected directory trees
-
-The template outputs are validated during testing using the directory tree files in the `scripts/expected-trees` directory. When files are added or removed from the template the expected directory trees will need to be updated. This can be done using the `test-templates.ps1` script with the `-GenerateExpectedTrees` parameter (`pwsh test-templates.ps1 -GenerateExpectedTrees`)
-
 ### Template usage
 
 #### Template installation

--- a/scripts/test-templates.ps1
+++ b/scripts/test-templates.ps1
@@ -182,11 +182,18 @@ if (!$GenerateExpectedTrees) {
     foreach ($project in $projects) {
         if ([string]::IsNullOrEmpty($Template) -or $($project.Name -eq $Template)) {
             Write-Output "Testing $($project.Name)"
-            & "$PSScriptRoot/compare-directory-files.ps1" -InputFile "$StacksDotnetDirectory/scripts/expected-trees/$($project.Name).tree" -Directory $TestTemplatesDirectory/$($project.Name)
-            if ($LASTEXITCODE -ne 0) {
-                Write-Error "Directory comparison failed for $($project.Name)"
-                exit $LASTEXITCODE
-            }
+
+            ############################
+            # Comparing the generated directory tree with the expected tree files was introduced in Cycle 15
+            # This is commented out as it proved cumbersome to maintain and was not providing much value
+            # It is left here to be revisited in the future
+            ############################
+            # & "$PSScriptRoot/compare-directory-files.ps1" -InputFile "$StacksDotnetDirectory/scripts/expected-trees/$($project.Name).tree" -Directory $TestTemplatesDirectory/$($project.Name)
+            # if ($LASTEXITCODE -ne 0) {
+            #     Write-Error "Directory comparison failed for $($project.Name)"
+            #     exit $LASTEXITCODE
+            # }
+
             Push-Location -Path $project.Path
             dotnet restore
             dotnet build


### PR DESCRIPTION
#### 📲 What

Comment out the comparison of generated trees in the test `test-templates.ps1`.

#### 🤔 Why

Doesn't generate on Windows
Developers forget to generate before PR wasting time
New developers won't easily understand the requirement

https://amido-dev.visualstudio.com/Amido-Stacks/_workitems/edit/8401

#### 🛠 How

- Comment out comparison line
- Add comment explaining the reason
- Remove from the README 

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
